### PR TITLE
fix setup scripts and add local development support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,14 @@
+# Required
+DB_HOST=postgres
+DB_PORT=5432
+DB_USER=pguser
+DB_PASSWORD=secret
+DB_NAME=providerdb
+
+# Optional (have defaults)
+SYSTEM_PORT=9090
+SYSTEM_ACCESS_TOKENS=
+SYSTEM_LOG_LEVEL=1        # 0-debug, 1-info, 2-warn, 3-error
+MASTER_ADDRESS=UQB3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d3d0x0
+TON_CONFIG_URL=https://ton-blockchain.github.io/global.config.json
+BATCH_SIZE=100

--- a/.gitignore
+++ b/.gitignore
@@ -6,8 +6,7 @@
 /.vscode
 /.vscode/*
 /.DS_Store
-/.env.*
 *.env
 *mtpo-backend
 *.log
-*myapp
+*.tar.gz

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:1.24 AS builder
+WORKDIR /app
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN go build -buildvcs=false -o mtpo-backend ./cmd
+
+FROM debian:12
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+WORKDIR /app
+COPY --from=builder /app/mtpo-backend .
+EXPOSE 9090 16167
+CMD ["./mtpo-backend"]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,4 @@
+.PHONY: test
+
+test:
+	@bats tests/*.bats

--- a/README.md
+++ b/README.md
@@ -52,9 +52,47 @@ PG_USER=pguser PG_PASSWORD=secret PG_DB=providerdb NEWFRONTENDUSER=jdfront NEWSU
 
 Upon completion, it will output useful information about server usage.
 
-## Dev:
+## Dev
+
+### Local Development
+
+#### Requirements
+
+- Docker
+- Docker Compose
+
+#### Quick Start
+
+1. Copy the environment file:
+
+```bash
+cp .env.example .env
+```
+
+2. Start the services:
+
+```bash
+docker compose up --build
+```
+
+The server will be available at `http://localhost:9090`.
+
+#### Stop
+
+```bash
+docker compose down
+```
+
+To fully clean up including database data:
+
+```bash
+docker compose down -v
+```
+
 ### VS Code Configuration
+
 Create `.vscode/launch.json`:
+
 ```json
 {
     "version": "0.2.0",

--- a/README.ru.md
+++ b/README.ru.md
@@ -53,8 +53,45 @@ PG_USER=pguser PG_PASSWORD=secret PG_DB=providerdb NEWFRONTENDUSER=jdfront NEWSU
 
 ## Разработка
 
+### Локальная разработка
+
+#### Требования
+
+- Docker
+- Docker Compose
+
+#### Быстрый старт
+
+1. Скопируйте файл окружения:
+
+```bash
+cp .env.example .env
+```
+
+2. Запустите сервисы:
+
+```bash
+docker compose up --build
+```
+
+Сервер будет доступен по адресу `http://localhost:9090`.
+
+#### Остановка
+
+```bash
+docker compose down
+```
+
+Для полной очистки, включая данные базы:
+
+```bash
+docker compose down -v
+```
+
 ### Конфигурация VS Code
+
 Создайте `.vscode/launch.json`:
+
 ```json
 {
     "version": "0.2.0",

--- a/db/init.sql
+++ b/db/init.sql
@@ -3,7 +3,7 @@
 
 CREATE SCHEMA providers AUTHORIZATION pguser;
 
-CREATE SCHEMA public AUTHORIZATION pg_database_owner;
+CREATE SCHEMA IF NOT EXISTS public AUTHORIZATION pg_database_owner;
 
 CREATE SCHEMA system AUTHORIZATION pguser;
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+# docker-compose.yml
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: ${DB_USER}
+      POSTGRES_PASSWORD: ${DB_PASSWORD}
+      POSTGRES_DB: ${DB_NAME}
+    ports:
+      - "5433:5432"
+    volumes:
+      - ./db/init.sql:/docker-entrypoint-initdb.d/init.sql
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER} -d ${DB_NAME}"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    build: .
+    env_file: .env
+    ports:
+      - "9090:9090"
+    depends_on:
+      postgres:
+        condition: service_healthy
+
+volumes:
+  postgres_data:

--- a/scripts/build_backend.sh
+++ b/scripts/build_backend.sh
@@ -21,6 +21,7 @@ DB_NAME=${PG_DB}
 SYSTEM_LOG_LEVEL=0
 EOL
 
+mkdir -p /opt/provider
 mv mtpo-backend /opt/provider/
 mv config.env /opt/provider/
 

--- a/scripts/build_backend.sh
+++ b/scripts/build_backend.sh
@@ -3,7 +3,7 @@
 # This script builds the backend application for the TON provider.
 # Also generates the .env file with necessary configurations.
 
-cd "$WORK_DIR/mytonprovider-backend/"
+cd "$WORK_DIR/mytonprovider-backend/" || exit
 
 go build -buildvcs=false -o mtpo-backend ./cmd
 

--- a/scripts/ib_disable_postgres_user.sh
+++ b/scripts/ib_disable_postgres_user.sh
@@ -2,7 +2,7 @@
 
 PGUSER_TO_BLOCK="postgres"
 
-PG_HBA_PATH="/etc/postgresql/15/main/pg_hba.conf"
+PG_HBA_PATH="/etc/postgresql/${PG_VERSION}/main/pg_hba.conf"
 
 cp "$PG_HBA_PATH" "${PG_HBA_PATH}.bak.$(date +%s)"
 

--- a/scripts/init_db.sh
+++ b/scripts/init_db.sh
@@ -4,7 +4,7 @@
 
 set -e
 
-SQL_FILE="../db/init.sql"
+SQL_FILE="$(dirname "$0")/../db/init.sql"
 
 if [[ -z "$PG_USER" || -z "$PG_PASSWORD" || -z "$PG_DB" ]]; then
     echo "❌ Missing required environment variables"

--- a/scripts/psql_setup.sh
+++ b/scripts/psql_setup.sh
@@ -25,6 +25,10 @@ sed -i "s/^#listen_addresses =.*/listen_addresses = '*'/" "$PG_CONF"
 sed -i "s/^listen_addresses = 'localhost'/listen_addresses = '*'/" "$PG_CONF"
 grep -q "0.0.0.0/0" "$PG_HBA" || echo "host    all             all             0.0.0.0/0               md5" >> "$PG_HBA"
 systemctl restart postgresql
+if ! systemctl is-active --quiet postgresql; then
+    echo "❌ PostgreSQL failed to start"
+    exit 1
+fi
 
 # create user
 echo "Creating PostgreSQL user and database..."

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -2,7 +2,9 @@
 
 cd /opt/provider
 
-env $(cat config.env | xargs) ./mtpo-backend >> /var/log/mytonprovider.app/mytonprovider.app.log 2>&1 &
+mkdir -p /var/log/mytonprovider.app
+
+env $(grep -v '^\s*$' config.env | grep -v '=$' | xargs) ./mtpo-backend >> /var/log/mytonprovider.app/mytonprovider.app.log 2>&1 &
 
 sleep 5
 

--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-cd /opt/provider
+cd /opt/provider || exit
 
 mkdir -p /var/log/mytonprovider.app
 

--- a/scripts/setup_server.sh
+++ b/scripts/setup_server.sh
@@ -16,7 +16,7 @@
 
 set -e
 
-PG_VERSION="15"
+PG_VERSION="${PG_VERSION:-15}"
 GITHUB_REPO="dearjohndoe/mytonprovider-backend"
 GITHUB_BRANCH="master"
 SCRIPTS_BASE_URL="https://raw.githubusercontent.com/$GITHUB_REPO/$GITHUB_BRANCH/scripts"

--- a/scripts/setup_server.sh
+++ b/scripts/setup_server.sh
@@ -133,10 +133,11 @@ install_deps() {
 
     if ! command -v go &> /dev/null && [ ! -f /usr/local/go/bin/go ]; then
         print_status "Installing Go..."
-        wget https://go.dev/dl/go1.24.5.linux-amd64.tar.gz
-        tar -C /usr/local -xzf go1.24.5.linux-amd64.tar.gz
+        GOARCH=$(dpkg --print-architecture)
+        wget https://go.dev/dl/go1.24.5.linux-${GOARCH}.tar.gz
+        tar -C /usr/local -xzf go1.24.5.linux-${GOARCH}.tar.gz
         echo 'export PATH=$PATH:/usr/local/go/bin' >> /etc/profile
-        rm go1.24.5.linux-amd64.tar.gz
+        rm go1.24.5.linux-${GOARCH}.tar.gz
     fi
 
     export PATH=$PATH:/usr/local/go/bin

--- a/tests/build_backend.bats
+++ b/tests/build_backend.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+source "$BATS_TEST_DIRNAME/test_helper.sh"
+
+setup() {
+  setup_test_env
+
+  export WORK_DIR="$TEST_TMPDIR/work"
+  export HOST="127.0.0.1"
+  export PG_USER="pguser"
+  export PG_PASSWORD="pgpass"
+  export PG_DB="providerdb"
+
+  mkdir -p "$WORK_DIR/mytonprovider-backend/cmd"
+
+  create_stub go '
+output=""
+prev=""
+for arg in "$@"; do
+  if [ "$prev" = "-o" ]; then
+    output="$arg"
+    break
+  fi
+  prev="$arg"
+done
+[ -n "$output" ] && : > "$output"
+exit 0
+'
+  create_stub mkdir 'exit 0'
+  create_stub mv 'exit 0'
+  create_stub psql 'exit 0'
+  create_stub systemctl 'exit 0'
+}
+
+teardown() {
+  teardown_test_env
+}
+
+@test "build_backend.sh creates /opt/provider before mv" {
+  run bash "$PROJECT_ROOT/scripts/build_backend.sh"
+
+  [ "$status" -eq 0 ]
+
+  local mkdir_line
+  local mv_line
+  mkdir_line=$(line_of_pattern 'mkdir|-p /opt/provider')
+  mv_line=$(line_of_pattern 'mv|mtpo-backend /opt/provider/')
+
+  [ "$mkdir_line" -gt 0 ]
+  [ "$mv_line" -gt 0 ]
+  [ "$mkdir_line" -lt "$mv_line" ]
+}

--- a/tests/init_db.bats
+++ b/tests/init_db.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+source "$BATS_TEST_DIRNAME/test_helper.sh"
+
+setup() {
+  setup_test_env
+  create_stub psql 'exit 0'
+  create_stub go 'exit 0'
+  create_stub systemctl 'exit 0'
+}
+
+teardown() {
+  teardown_test_env
+}
+
+@test "init_db.sh exits with code 1 when required env vars are missing" {
+  run env -i PATH="$PATH" bash "$PROJECT_ROOT/scripts/init_db.sh"
+
+  [ "$status" -eq 1 ]
+}
+
+@test "init_db.sh prints missing variables error message" {
+  run env -i PATH="$PATH" bash "$PROJECT_ROOT/scripts/init_db.sh"
+
+  [ "$status" -eq 1 ]
+  assert_output_contains "Missing required environment variables"
+}
+
+@test "init_db.sh passes SQL path resolved from script dirname" {
+  local random_cwd="$TEST_TMPDIR/random-cwd"
+  mkdir -p "$random_cwd"
+
+  run bash -c '
+    set -e
+    cd "$1"
+    PG_USER=user PG_PASSWORD=pass PG_DB=db PATH="$2" bash "$3"
+  ' -- "$random_cwd" "$PATH" "$PROJECT_ROOT/scripts/init_db.sh"
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "psql|-h 127.0.0.1 -p 5432 -U user -d db -f $PROJECT_ROOT/scripts/../db/init.sql"
+}

--- a/tests/init_db.bats
+++ b/tests/init_db.bats
@@ -22,8 +22,15 @@ teardown() {
 @test "init_db.sh prints missing variables error message" {
   run env -i PATH="$PATH" bash "$PROJECT_ROOT/scripts/init_db.sh"
 
-  [ "$status" -eq 1 ]
   assert_output_contains "Missing required environment variables"
+}
+
+@test "init_db.sh exits with code 1 when psql fails" {
+  create_stub psql 'exit 1'
+
+  run env -i PATH="$PATH" PG_USER=user PG_PASSWORD=pass PG_DB=db bash "$PROJECT_ROOT/scripts/init_db.sh"
+
+  [ "$status" -eq 1 ]
 }
 
 @test "init_db.sh passes SQL path resolved from script dirname" {

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -54,3 +54,13 @@ run_script_with_overridden_cd() {
 
   [ "$status" -eq 0 ]
 }
+
+@test "run.sh exits with code 1 when backend process is not found after start" {
+  create_stub pgrep 'exit 1'
+  export SCRIPT="$PROJECT_ROOT/scripts/run.sh"
+
+  run_script_with_overridden_cd
+
+  [ "$status" -eq 1 ]
+}
+

--- a/tests/run.bats
+++ b/tests/run.bats
@@ -1,0 +1,56 @@
+#!/usr/bin/env bats
+
+source "$BATS_TEST_DIRNAME/test_helper.sh"
+
+setup() {
+  setup_test_env
+
+  export PROVIDER_DIR="$TEST_TMPDIR/provider"
+  mkdir -p "$PROVIDER_DIR"
+  : > "$PROVIDER_DIR/mtpo-backend"
+  chmod +x "$PROVIDER_DIR/mtpo-backend"
+
+  # Empty value should not break env parsing.
+  cat > "$PROVIDER_DIR/config.env" <<'CFG'
+SYSTEM_PORT=9090
+SYSTEM_ACCESS_TOKENS=
+DB_HOST=127.0.0.1
+CFG
+
+  create_stub mkdir 'exit 0'
+  create_stub pgrep 'exit 0'
+  create_stub sleep 'exit 0'
+  create_stub env 'exit 0'
+  create_stub go 'exit 0'
+  create_stub psql 'exit 0'
+  create_stub systemctl 'exit 0'
+}
+
+teardown() {
+  teardown_test_env
+}
+
+run_script_with_overridden_cd() {
+  run bash -c '
+    cd() { builtin cd "$PROVIDER_DIR"; }
+    export -f cd
+    source "$SCRIPT"
+  '
+}
+
+@test "run.sh creates /var/log/mytonprovider.app with mkdir -p" {
+  export SCRIPT="$PROJECT_ROOT/scripts/run.sh"
+
+  run_script_with_overridden_cd
+
+  [ "$status" -eq 0 ]
+  assert_log_contains "mkdir|-p /var/log/mytonprovider.app"
+}
+
+@test "run.sh does not fail with empty values in config.env" {
+  export SCRIPT="$PROJECT_ROOT/scripts/run.sh"
+
+  run_script_with_overridden_cd
+
+  [ "$status" -eq 0 ]
+}

--- a/tests/test_helper.sh
+++ b/tests/test_helper.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+# Shared helpers for Bats tests.
+
+setup_test_env() {
+  export PROJECT_ROOT
+  PROJECT_ROOT="$(cd "${BATS_TEST_DIRNAME}/.." && pwd)"
+
+  export TEST_TMPDIR
+  TEST_TMPDIR="$(mktemp -d "${TMPDIR:-/tmp}/bats-mytonprovider.XXXXXX")"
+
+  export STUBS_DIR="${TEST_TMPDIR}/stubs"
+  export STUB_LOG="${TEST_TMPDIR}/stubs.log"
+  mkdir -p "$STUBS_DIR"
+  : > "$STUB_LOG"
+
+  export ORIGINAL_PATH="$PATH"
+  export PATH="$STUBS_DIR:$PATH"
+}
+
+teardown_test_env() {
+  export PATH="$ORIGINAL_PATH"
+  rm -rf "$TEST_TMPDIR"
+}
+
+create_stub() {
+  local cmd="$1"
+  local body="${2:-exit 0}"
+
+  {
+    printf '%s\n' '#!/usr/bin/env bash'
+    printf '%s\n' 'set -e'
+    printf '%s\n' 'if [ -n "${STUB_LOG:-}" ]; then'
+    printf '%s\n' "  printf '%s|%s\\n' '$cmd' \"\$*\" >> \"\$STUB_LOG\""
+    printf '%s\n' 'fi'
+    printf '%s\n' "$body"
+  } > "$STUBS_DIR/$cmd"
+
+  chmod +x "$STUBS_DIR/$cmd"
+}
+
+assert_output_contains() {
+  local expected="$1"
+  # shellcheck disable=SC2154
+  [[ "$output" == *"$expected"* ]]
+}
+
+assert_log_contains() {
+  local expected="$1"
+  grep -F "$expected" "$STUB_LOG" >/dev/null
+}
+
+line_of_pattern() {
+  local pattern="$1"
+  local line
+  line=$(grep -n "$pattern" "$STUB_LOG" | head -n 1 | cut -d: -f1)
+  echo "${line:-0}"
+}

--- a/tests/test_helper.sh
+++ b/tests/test_helper.sh
@@ -42,7 +42,11 @@ create_stub() {
 assert_output_contains() {
   local expected="$1"
   # shellcheck disable=SC2154
-  [[ "$output" == *"$expected"* ]]
+  [[ "$output" == *"$expected"* ]] || {
+    echo "Expected output to contain: $expected"
+    echo "Actual output: $output"
+    return 1
+  }
 }
 
 assert_log_contains() {
@@ -53,6 +57,6 @@ assert_log_contains() {
 line_of_pattern() {
   local pattern="$1"
   local line
-  line=$(grep -n "$pattern" "$STUB_LOG" | head -n 1 | cut -d: -f1)
+  line=$(grep -Fn "$pattern" "$STUB_LOG" | head -n 1 | cut -d: -f1)
   echo "${line:-0}"
 }


### PR DESCRIPTION
## Что сделано

Исправлены баги в скриптах установки и добавлена локальная разработка.

## Изменения

**Баг фиксы:**
- `setup_server.sh` — `PG_VERSION` теперь можно переопределить через env (было захардкожено "15")
- `psql_setup.sh` — добавлена проверка после `systemctl restart postgresql`, скрипт падает сразу если postgres не запустился
- `ib_disable_postgres_user.sh` — хардкод `/etc/postgresql/15/` заменён на `${PG_VERSION}`
- `build_backend.sh` — добавлен `mkdir -p /opt/provider` перед `mv`
- `init_db.sh` — относительный путь `../db/init.sql` заменён на абсолютный через `$(dirname "$0")`
- `run.sh` — добавлен `mkdir -p /var/log/mytonprovider.app` и починен `env $(cat config.env | xargs)` который ломался на пустых значениях
- `db/init.sql` — добавлен `IF NOT EXISTS` в `CREATE SCHEMA public` чтобы не падало на свежем postgres

**Локальная разработка:**
- Добавлены `Dockerfile` и `docker-compose.yml` для запуска одной командой
- Добавлен `.env.example` со всеми доступными параметрами конфигурации
- Обновлены README (EN и RU) с секцией локальной разработки

## Тестирование

Проверен полный локальный запуск:
```bash
cp .env.example .env
docker compose up --build
```

Проверен запуск `setup_server.sh` на чистом Debian 12 — сервер поднялся успешно.
